### PR TITLE
result/processors: make exclusion_paths apply to typecheck issues and…

### DIFF
--- a/docs/content/docs/linters/false-positives.md
+++ b/docs/content/docs/linters/false-positives.md
@@ -113,28 +113,6 @@ linters:
       - path/to/a/dir/
 ```
 
-**Note**: The `linters.exclusions.paths` setting only affects linter reports. If you want to exclude paths from formatters (like `gofmt`, `goimports`, etc.), you need to use `formatters.exclusions.paths`:
-
-```yaml
-formatters:
-  exclusions:
-    paths:
-      - path/to/a/dir/
-```
-
-Or you can set both to exclude the same paths from both linters and formatters:
-
-```yaml
-linters:
-  exclusions:
-    paths:
-      - web/app
-formatters:
-  exclusions:
-    paths:
-      - web/app
-```
-
 ## Nolint Directive
 
 To exclude issues from all linters use `//nolint:all`.

--- a/docs/content/docs/linters/false-positives.md
+++ b/docs/content/docs/linters/false-positives.md
@@ -113,6 +113,28 @@ linters:
       - path/to/a/dir/
 ```
 
+**Note**: The `linters.exclusions.paths` setting only affects linter reports. If you want to exclude paths from formatters (like `gofmt`, `goimports`, etc.), you need to use `formatters.exclusions.paths`:
+
+```yaml
+formatters:
+  exclusions:
+    paths:
+      - path/to/a/dir/
+```
+
+Or you can set both to exclude the same paths from both linters and formatters:
+
+```yaml
+linters:
+  exclusions:
+    paths:
+      - web/app
+formatters:
+  exclusions:
+    paths:
+      - web/app
+```
+
 ## Nolint Directive
 
 To exclude issues from all linters use `//nolint:all`.

--- a/pkg/result/processors/exclusion_paths.go
+++ b/pkg/result/processors/exclusion_paths.go
@@ -73,8 +73,6 @@ func (p *ExclusionPaths) Process(issues []*result.Issue) ([]*result.Issue, error
 		return issues, nil
 	}
 
-	// Use unsafe filtering so path-based exclusions also apply to typecheck issues
-	// when users explicitly configured path exclusions.
 	return filterIssuesUnsafe(issues, p.shouldPassIssue), nil
 }
 
@@ -95,7 +93,6 @@ func (p *ExclusionPaths) Finish() {
 }
 
 func (p *ExclusionPaths) shouldPassIssue(issue *result.Issue) bool {
-	// Ensure we have a non-empty path to match against.
 	if issue.RelativePath == "" {
 		if issue.WorkingDirectoryRelativePath != "" {
 			issue.RelativePath = issue.WorkingDirectoryRelativePath

--- a/pkg/result/processors/path_relativity.go
+++ b/pkg/result/processors/path_relativity.go
@@ -44,7 +44,6 @@ func (p *PathRelativity) Process(issues []*result.Issue) ([]*result.Issue, error
 		newIssue.RelativePath, err = filepath.Rel(p.basePath, issue.FilePath())
 		if err != nil || newIssue.RelativePath == "" {
 			p.log.Warnf("Getting relative path (basepath): %v", err)
-			// Fallback to absolute filepath so downstream processors can still match.
 			newIssue.RelativePath = issue.FilePath()
 		}
 

--- a/pkg/result/processors/path_relativity.go
+++ b/pkg/result/processors/path_relativity.go
@@ -42,15 +42,16 @@ func (p *PathRelativity) Process(issues []*result.Issue) ([]*result.Issue, error
 
 		var err error
 		newIssue.RelativePath, err = filepath.Rel(p.basePath, issue.FilePath())
-		if err != nil {
+		if err != nil || newIssue.RelativePath == "" {
 			p.log.Warnf("Getting relative path (basepath): %v", err)
-			return nil
+			// Fallback to absolute filepath so downstream processors can still match.
+			newIssue.RelativePath = issue.FilePath()
 		}
 
 		newIssue.WorkingDirectoryRelativePath, err = filepath.Rel(p.workingDirectory, issue.FilePath())
-		if err != nil {
+		if err != nil || newIssue.WorkingDirectoryRelativePath == "" {
 			p.log.Warnf("Getting relative path (wd): %v", err)
-			return nil
+			newIssue.WorkingDirectoryRelativePath = issue.FilePath()
 		}
 
 		return &newIssue


### PR DESCRIPTION
… ensure robust path matching

- Use filterIssuesUnsafe in exclusion_paths to honor explicit path exclusions for typecheck reports
- Fallback to absolute/WD-relative paths in path_relativity when Rel() fails or yields empty, so exclusions can match reliably
- Update docs to clarify difference between linters.exclusions.paths and formatters.exclusions.paths

<!--

WARNING:

We use Dependabot to update dependencies (linters included).
The updates happen at least automatically once a week (Sunday 11am UTC).

No pull requests to update a linter will be accepted unless you are the author of the linter AND specific changes are required.

-->

<!--

WARNING:

Pull requests from a fork inside a GitHub organization are not allowed.
Only pull requests from personal forks are allowed. 

-->
